### PR TITLE
✨ :: (#10) 이메일 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,19 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	runtimeOnly 'mysql:mysql-connector-java'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/project/draw/domain/user/domain/AuthCode.java
+++ b/src/main/java/com/project/draw/domain/user/domain/AuthCode.java
@@ -1,0 +1,34 @@
+package com.project.draw.domain.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Builder
+@RedisHash
+public class AuthCode {
+
+    @Id
+    private final String email;
+
+    private String code;
+
+    private boolean isVerified;
+
+    @TimeToLive
+    private long ttl;
+
+    public void updateAuthCode(String code, long ttl) {
+        this.code = code;
+        this.ttl = ttl;
+        this.isVerified = false;
+    }
+
+    public void verify() {
+        this.isVerified = true;
+    }
+
+}

--- a/src/main/java/com/project/draw/domain/user/domain/repository/AuthCodeRepository.java
+++ b/src/main/java/com/project/draw/domain/user/domain/repository/AuthCodeRepository.java
@@ -1,0 +1,9 @@
+package com.project.draw.domain.user.domain.repository;
+
+import com.project.draw.domain.user.domain.AuthCode;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuthCodeRepository extends CrudRepository<AuthCode, String> {
+}

--- a/src/main/java/com/project/draw/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/project/draw/domain/user/domain/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends CrudRepository<User, Long> {
     Optional<User> findByAccountId(String accountId);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/project/draw/domain/user/exception/BadAuthCodeException.java
+++ b/src/main/java/com/project/draw/domain/user/exception/BadAuthCodeException.java
@@ -1,0 +1,11 @@
+package com.project.draw.domain.user.exception;
+
+import com.project.draw.global.error.exception.BusinessException;
+import com.project.draw.global.error.exception.ErrorCode;
+
+public class BadAuthCodeException extends BusinessException {
+    public static final BusinessException EXCEPTION = new BadAuthCodeException();
+    private BadAuthCodeException(){
+        super(ErrorCode.BAD_AUTH_CODE);
+    }
+}

--- a/src/main/java/com/project/draw/domain/user/exception/BadEmailException.java
+++ b/src/main/java/com/project/draw/domain/user/exception/BadEmailException.java
@@ -1,0 +1,11 @@
+package com.project.draw.domain.user.exception;
+
+import com.project.draw.global.error.exception.BusinessException;
+import com.project.draw.global.error.exception.ErrorCode;
+
+public class BadEmailException extends BusinessException {
+    public static final BusinessException EXCEPTION = new BadEmailException();
+    private BadEmailException(){
+        super(ErrorCode.BAD_EMAIL);
+    }
+}

--- a/src/main/java/com/project/draw/domain/user/exception/UnverifiedEmailException.java
+++ b/src/main/java/com/project/draw/domain/user/exception/UnverifiedEmailException.java
@@ -1,0 +1,11 @@
+package com.project.draw.domain.user.exception;
+
+import com.project.draw.global.error.exception.BusinessException;
+import com.project.draw.global.error.exception.ErrorCode;
+
+public class UnverifiedEmailException extends BusinessException {
+    public static final BusinessException EXCEPTION = new UnverifiedEmailException();
+    private UnverifiedEmailException() {
+        super(ErrorCode.UNVERIFIED_EMAIL);
+    }
+}

--- a/src/main/java/com/project/draw/domain/user/facade/AuthCodeFacade.java
+++ b/src/main/java/com/project/draw/domain/user/facade/AuthCodeFacade.java
@@ -1,0 +1,79 @@
+package com.project.draw.domain.user.facade;
+
+import com.project.draw.domain.user.domain.AuthCode;
+import com.project.draw.domain.user.domain.repository.AuthCodeRepository;
+import com.project.draw.domain.user.exception.BadAuthCodeException;
+import com.project.draw.domain.user.exception.BadEmailException;
+import com.project.draw.domain.user.exception.UnverifiedEmailException;
+import com.project.draw.global.util.jms.JmsProperties;
+import com.project.draw.global.util.jms.JmsUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Component
+public class AuthCodeFacade {
+
+    public static final Random RANDOM = new Random();
+    private final AuthCodeRepository authCodeRepository;
+    private final JmsUtil jmsUtil;
+    private final JmsProperties jmsProperties;
+
+    public void verifyAuthCode(String code, String email) {
+
+        AuthCode authCode = authCodeRepository.findById(email)
+                .filter(a -> a.getCode().equals(code))
+                .orElseThrow(() -> BadAuthCodeException.EXCEPTION);
+
+        authCode.verify();
+        authCodeRepository.save(authCode);
+    }
+
+    public void checkIsVerified(String email) {
+        authCodeRepository.findById(email)
+                .filter(AuthCode::isVerified)
+                .orElseThrow(() -> UnverifiedEmailException.EXCEPTION);
+    }
+
+    public void checkEmailDomain(String email) {
+        if(!email.endsWith(jmsProperties.getSuffix())) {
+            throw BadEmailException.EXCEPTION;
+        }
+    }
+
+    public void sendMail(String email) {
+
+        String code = createRandomCode();
+        AuthCode authCode = getAuthCode(email, code);
+        authCodeRepository.save(authCode);
+
+        jmsUtil.sendMail(email, authCode.getCode());
+    }
+
+    private AuthCode getAuthCode(String email, String code) {
+
+        AuthCode authCode = authCodeRepository.findById(email)
+                .orElseGet(() -> createAuthCode(email, code));
+
+        authCode.updateAuthCode(code, jmsProperties.getAuthExp());
+
+        return authCode;
+    }
+
+    private AuthCode createAuthCode(String email, String code) {
+        return AuthCode
+                .builder()
+                .email(email)
+                .code(code)
+                .isVerified(false)
+                .ttl(jmsProperties.getAuthExp())
+                .build();
+    }
+
+    private String createRandomCode() {
+        return String.format("%06d", RANDOM.nextInt(1000000) % 1000000);
+    }
+
+}

--- a/src/main/java/com/project/draw/domain/user/facade/UserFacade.java
+++ b/src/main/java/com/project/draw/domain/user/facade/UserFacade.java
@@ -1,7 +1,5 @@
 package com.project.draw.domain.user.facade;
 
-import com.project.draw.domain.chat.exception.RoomNotFoundException;
-import com.project.draw.domain.chat.exception.UnableJoinException;
 import com.project.draw.domain.user.domain.User;
 import com.project.draw.domain.user.domain.repository.UserRepository;
 import com.project.draw.domain.user.exception.UserNotFoundException;
@@ -30,13 +28,7 @@ public class UserFacade {
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
     }
 
-    public User getUserNotJoined(String accountId) {
-        return userRepository.findUserNotJoined(accountId)
-                .orElseThrow(() -> UnableJoinException.EXCEPTION);
-    }
-
-    public User getUserAndFetchRoom(String accountId) {
-        return userRepository.findUserAndFetchRoom(accountId)
-                .orElseThrow(() -> RoomNotFoundException.EXCEPTION);
+    public boolean emailIsExist(String email) {
+        return userRepository.findByEmail(email).isPresent();
     }
 }

--- a/src/main/java/com/project/draw/domain/user/presentation/UserController.java
+++ b/src/main/java/com/project/draw/domain/user/presentation/UserController.java
@@ -1,17 +1,30 @@
 package com.project.draw.domain.user.presentation;
 
 import com.project.draw.domain.auth.presentation.dto.TokenResponse;
+import com.project.draw.domain.user.presentation.dto.request.CheckEmailRequest;
+import com.project.draw.domain.user.presentation.dto.request.FindPasswordRequest;
 import com.project.draw.domain.user.presentation.dto.request.LoginRequest;
+import com.project.draw.domain.user.presentation.dto.request.SendAuthCodeRequest;
 import com.project.draw.domain.user.presentation.dto.request.SignupRequest;
+import com.project.draw.domain.user.presentation.dto.request.UpdatePasswordRequest;
 import com.project.draw.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import com.project.draw.domain.user.presentation.dto.request.VerifyAuthCodeRequest;
+import com.project.draw.domain.user.presentation.dto.response.FindAccountIdResponse;
 import com.project.draw.domain.user.presentation.dto.response.QueryUserInfoResponse;
+import com.project.draw.domain.user.service.CheckEmailService;
+import com.project.draw.domain.user.service.FindAccountIdService;
+import com.project.draw.domain.user.service.FindPasswordService;
 import com.project.draw.domain.user.service.LoginService;
 import com.project.draw.domain.user.service.LogoutService;
 import com.project.draw.domain.user.service.QueryMyInfoService;
 import com.project.draw.domain.user.service.QueryUserInfoService;
+import com.project.draw.domain.user.service.SendAuthCodeService;
+import com.project.draw.domain.user.service.SendSignupAuthCodeService;
 import com.project.draw.domain.user.service.SignupService;
 import com.project.draw.domain.user.service.TokenRefreshService;
+import com.project.draw.domain.user.service.UpdatePasswordService;
 import com.project.draw.domain.user.service.UpdateUserInfoService;
+import com.project.draw.domain.user.service.VerifyAuthCodeService;
 import com.project.draw.domain.user.service.WithdrawalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,14 +47,44 @@ import javax.validation.Valid;
 @RestController
 public class UserController {
 
+    private final CheckEmailService checkEmailService;
+    private final SendSignupAuthCodeService sendSignupAuthCodeService;
+    private final VerifyAuthCodeService verifyAuthCodeService;
+
     private final SignupService signupService;
     private final LoginService loginService;
     private final TokenRefreshService tokenRefreshService;
-    private final UpdateUserInfoService updateUserInfoService;
+
     private final QueryMyInfoService queryMyInfoService;
     private final QueryUserInfoService queryUserInfoService;
+
+    private final UpdateUserInfoService updateUserInfoService;
+    private final UpdatePasswordService updatePasswordService;
+
+    private final SendAuthCodeService sendAuthCodeService;
+    private final FindPasswordService findPasswordService;
+    private final FindAccountIdService findAccountIdService;
+
     private final LogoutService logoutService;
     private final WithdrawalService withdrawalService;
+
+    @PostMapping("/mail/duplicate")
+    public void checkEmail(@RequestBody @Valid CheckEmailRequest request){
+        checkEmailService.execute(request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/mail/signup")
+    public void sendSignupAuthCodeService(@RequestBody @Valid SendAuthCodeRequest request){
+        sendSignupAuthCodeService.execute(request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/mail/verify")
+    public void verifyAuthCode(@RequestBody @Valid VerifyAuthCodeRequest request) {
+        verifyAuthCodeService.execute(request);
+    }
+
 
     @PostMapping
     public TokenResponse signup(@RequestBody @Valid SignupRequest request){
@@ -66,8 +109,8 @@ public class UserController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/password")
-    public void updateUserPassword(@RequestBody @Valid UpdateUserInfoRequest request) {
-        updateUserInfoService.execute(request);
+    public void updateUserPassword(@RequestBody @Valid UpdatePasswordRequest request) {
+        updatePasswordService.execute(request);
     }
 
     @GetMapping
@@ -78,6 +121,23 @@ public class UserController {
     @GetMapping("/{user-id}")
     public QueryUserInfoResponse queryUserInfo(@PathVariable("user-id") Long userId) {
         return queryUserInfoService.execute(userId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/mail")
+    public void sendAuthCodeService(@RequestBody @Valid SendAuthCodeRequest request){
+        sendAuthCodeService.execute(request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/password")
+    public void findPassword(@RequestBody @Valid FindPasswordRequest request) {
+        findPasswordService.execute(request);
+    }
+
+    @GetMapping("/account-id")
+    public FindAccountIdResponse findPassword() {
+        return findAccountIdService.execute();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/project/draw/domain/user/presentation/dto/request/CheckEmailRequest.java
+++ b/src/main/java/com/project/draw/domain/user/presentation/dto/request/CheckEmailRequest.java
@@ -1,0 +1,15 @@
+package com.project.draw.domain.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+public class CheckEmailRequest {
+
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$")
+    private String email;
+
+}

--- a/src/main/java/com/project/draw/domain/user/presentation/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/project/draw/domain/user/presentation/dto/request/FindPasswordRequest.java
@@ -1,0 +1,16 @@
+package com.project.draw.domain.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+public class FindPasswordRequest {
+
+    @NotBlank(message = "new_password는 Null 또는 공백 또는 띄어쓰기를 허용하지 않습니다.")
+    @Pattern(regexp = "(?=.*[a-z])(?=.*[0-9])(?=.*[~!@#$%^&*()_+-=?/])[a-zA-Z0-9~!@#$%^&*()_+-=?/]{8,30}$", message = "password는 8-20자여야합니다.")
+    String newPassword;
+}

--- a/src/main/java/com/project/draw/domain/user/presentation/dto/request/SendAuthCodeRequest.java
+++ b/src/main/java/com/project/draw/domain/user/presentation/dto/request/SendAuthCodeRequest.java
@@ -1,0 +1,14 @@
+package com.project.draw.domain.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@NoArgsConstructor
+public class SendAuthCodeRequest {
+
+    @Email
+    private String email;
+}

--- a/src/main/java/com/project/draw/domain/user/presentation/dto/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/com/project/draw/domain/user/presentation/dto/request/VerifyAuthCodeRequest.java
@@ -1,0 +1,20 @@
+package com.project.draw.domain.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor
+public class VerifyAuthCodeRequest {
+
+    @NotBlank
+    @Size(min = 6, max = 6)
+    private String authCode;
+
+    @Email
+    private String email;
+}

--- a/src/main/java/com/project/draw/domain/user/service/CheckEmailService.java
+++ b/src/main/java/com/project/draw/domain/user/service/CheckEmailService.java
@@ -1,0 +1,30 @@
+package com.project.draw.domain.user.service;
+
+import com.project.draw.domain.user.exception.UserAlreadyExistException;
+import com.project.draw.domain.user.facade.AuthCodeFacade;
+import com.project.draw.domain.user.facade.UserFacade;
+import com.project.draw.domain.user.presentation.dto.request.CheckEmailRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CheckEmailService {
+
+    private final UserFacade userFacade;
+    private final AuthCodeFacade authCodeFacade;
+
+    @Transactional(readOnly = true)
+    public void execute(CheckEmailRequest request) {
+
+        String email = request.getEmail();
+
+        authCodeFacade.checkEmailDomain(email);
+
+        if(userFacade.emailIsExist(email)) {
+            throw UserAlreadyExistException.EXCEPTION;
+        }
+    }
+
+}

--- a/src/main/java/com/project/draw/domain/user/service/SendAuthCodeService.java
+++ b/src/main/java/com/project/draw/domain/user/service/SendAuthCodeService.java
@@ -1,0 +1,29 @@
+package com.project.draw.domain.user.service;
+
+import com.project.draw.domain.user.exception.UserNotFoundException;
+import com.project.draw.domain.user.facade.AuthCodeFacade;
+import com.project.draw.domain.user.facade.UserFacade;
+import com.project.draw.domain.user.presentation.dto.request.SendAuthCodeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Service
+public class SendAuthCodeService {
+
+    private final AuthCodeFacade authCodeFacade;
+    private final UserFacade userFacade;
+
+    public void execute(@Valid SendAuthCodeRequest request) {
+
+        String email = request.getEmail();
+
+        if (!userFacade.emailIsExist(email)) {
+            throw UserNotFoundException.EXCEPTION;
+        }
+
+        authCodeFacade.sendMail(email);
+    }
+}

--- a/src/main/java/com/project/draw/domain/user/service/SendSignupAuthCodeService.java
+++ b/src/main/java/com/project/draw/domain/user/service/SendSignupAuthCodeService.java
@@ -1,0 +1,29 @@
+package com.project.draw.domain.user.service;
+
+import com.project.draw.domain.user.exception.UserAlreadyExistException;
+import com.project.draw.domain.user.facade.AuthCodeFacade;
+import com.project.draw.domain.user.facade.UserFacade;
+import com.project.draw.domain.user.presentation.dto.request.SendAuthCodeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Service
+public class SendSignupAuthCodeService {
+
+    private final UserFacade userFacade;
+    private final AuthCodeFacade authCodeFacade;
+
+    public void execute(@Valid SendAuthCodeRequest request) {
+
+        String email = request.getEmail();
+
+        if(userFacade.emailIsExist(request.getEmail())) {
+            throw UserAlreadyExistException.EXCEPTION;
+        }
+
+        authCodeFacade.sendMail(email);
+    }
+}

--- a/src/main/java/com/project/draw/domain/user/service/SignupService.java
+++ b/src/main/java/com/project/draw/domain/user/service/SignupService.java
@@ -39,6 +39,8 @@ public class SignupService {
             throw UserAlreadyExistException.EXCEPTION;
         }
 
+        authCodeFacade.checkIsVerified(email);
+
         userRepository.save(User.builder()
                 .accountId(accountId)
                 .name(name)

--- a/src/main/java/com/project/draw/domain/user/service/VerifyAuthCodeService.java
+++ b/src/main/java/com/project/draw/domain/user/service/VerifyAuthCodeService.java
@@ -1,0 +1,22 @@
+package com.project.draw.domain.user.service;
+
+import com.project.draw.domain.user.facade.AuthCodeFacade;
+import com.project.draw.domain.user.presentation.dto.request.VerifyAuthCodeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class VerifyAuthCodeService {
+
+    private final AuthCodeFacade authCodeFacade;
+
+    public void execute(VerifyAuthCodeRequest request){
+
+        String authCode = request.getAuthCode();
+        String email = request.getEmail();
+
+        authCodeFacade.verifyAuthCode(authCode, email);
+    }
+
+}

--- a/src/main/java/com/project/draw/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/project/draw/global/error/exception/ErrorCode.java
@@ -10,15 +10,19 @@ import lombok.Getter;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorCode {
 
-
     EXPIRED_TOKEN(401,"AUTH-401-1", "Expired Token" ),
     INVALID_TOKEN(401,"AUTH-401-2","Invalid Token"),
     REFRESH_TOKEN_NOT_FOUND(404, "AUTH-404-1", "Refresh Token Not Found"),
 
-    PASSWORD_NOT_VALID(401, "USER-401-1", "Password Not Valid"),
+    BAD_EMAIL(400, "USER-400-1", "Bad Email Domain"),
+    BAD_AUTH_CODE(400, "USER-400-2", "Bad Auth Code"),
+
+    UNVERIFIED_EMAIL(401, "USER-401-1", "Unverified Email"),
+    PASSWORD_NOT_VALID(401, "USER-401-2", "Password Not Valid"),
     USER_NOT_FOUND(404, "USER-404-2", "User Not Found" ),
     USER_ALREADY_EXIST(409, "USER-409-1", "User Already Exist"),
 
+    MAIL_SEND_FAIL(404, "MAIL-404-1","Mail Send Fail"),
     INTERNAL_SERVER_ERROR(500, "SERVER-500-1", "Internal Server Error");
 
     private final Integer status;

--- a/src/main/java/com/project/draw/global/exception/MailSendException.java
+++ b/src/main/java/com/project/draw/global/exception/MailSendException.java
@@ -1,0 +1,12 @@
+package com.project.draw.global.exception;
+
+import com.project.draw.global.error.exception.BusinessException;
+import com.project.draw.global.error.exception.ErrorCode;
+
+public class MailSendException extends BusinessException {
+    public static final BusinessException EXCEPTION = new MailSendException();
+    private MailSendException(){
+        super(ErrorCode.MAIL_SEND_FAIL);
+    }
+
+}

--- a/src/main/java/com/project/draw/global/util/jms/JmsProperties.java
+++ b/src/main/java/com/project/draw/global/util/jms/JmsProperties.java
@@ -1,0 +1,17 @@
+package com.project.draw.global.util.jms;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@AllArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.mail")
+public class JmsProperties {
+
+    private final String username;
+    private final Integer authExp;
+    private final String suffix;
+}

--- a/src/main/java/com/project/draw/global/util/jms/JmsUtil.java
+++ b/src/main/java/com/project/draw/global/util/jms/JmsUtil.java
@@ -1,0 +1,61 @@
+package com.project.draw.global.util.jms;
+
+import com.project.draw.global.exception.MailSendException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+public class JmsUtil {
+
+    private final JmsProperties jmsProperties;
+    private final JavaMailSender mailSender;
+
+    public void sendMail(String email, String authenticationCode) {
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, false, "UTF-8");
+
+            messageHelper.setTo(email);
+            messageHelper.setFrom(jmsProperties.getUsername());
+            messageHelper.setSubject("[Draw] 이메일 인증");
+
+            String text = getFormattedString(authenticationCode.split(""));
+            boolean isHTML = true;
+
+            messageHelper.setText(text,isHTML);
+
+            mailSender.send(message);
+        } catch (Exception e){
+            throw MailSendException.EXCEPTION;
+        }
+
+    }
+
+    private String getFormattedString(String[] codes) {
+        return String.format(getMailTemplate(),
+                codes[0],
+                codes[1],
+                codes[2],
+                codes[3],
+                codes[4],
+                codes[5]);
+    }
+
+    private String getMailTemplate(){
+        try {
+            byte[] bytes = new ClassPathResource("static/email_template.html").getInputStream().readAllBytes();
+            return new String(bytes);
+        } catch (IOException e) {
+            throw MailSendException.EXCEPTION;
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,4 @@
 spring:
-  sql:
-    init:
-      schema-locations: classpath:dropProcedures.sql, classpath:createProcedures.sql
-      separator: $$
-      mode: always
-
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${URL}
@@ -14,9 +8,31 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      format_sql: true
+      generate-ddl: false
     defer-datasource-initialization: true
+    show-sql: true
   jackson:
     property-naming-strategy: SNAKE_CASE
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL-USERNAME}
+    password: ${EMAIL-PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            protocols: TLSv1.3
+          starttls:
+            enable: true
+            required: true
+
+    auth-exp: ${AUTH-CODE-EXP}
+    suffix: '${MAIL-SUFFIX}'
 
 redis:
   port: ${REDIS-PORT}

--- a/src/main/resources/static/email_template.html
+++ b/src/main/resources/static/email_template.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Transitional//EN""http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+    <style>@font-face {
+        font-family: 'paybooc-Bold';
+        src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-07@1.0/paybooc-Bold.woff') format('woff');
+        font-weight: normal;
+        font-style: normal;
+    }</style>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<table border-style="solid" width="600px"
+       style="font-family: 'paybooc-Bold'; letter-spacing :-0.7px; margin: auto;  background-color: #FFFFFF; ">
+    <tr>
+        <td style="padding: 140px 60px 28px 60px">
+            <table border-style="none" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td>
+                        <hr style="height : 3px; background-color :#000000; border : 0;"/>
+                    </td>
+                </tr>
+                <tr><td>&nbsp;</td></tr>
+                <tr>
+                    <th style="text-align: left; font-size: 29px; font-weight: 900;">Draw 메일 인증 안내입니다.</th>
+                </tr>
+                <tr>
+                    <td style="font-size: 0; height: 12px">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="font-size: 17px; line-height: 1.6em; font-weight: 400;">Draw를 이용해주셔서 감사합니다.<br>아래 인증코드를
+                        입력하여 회원가입을 완료해주세요.
+                    </td>
+                </tr>
+                <tr>
+                    <td style="font-size: 0; height: 64px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="font-size: 18px; font-weight: bold;">인증코드</td>
+                </tr>
+                <tr>
+                    <td style="font-size: 0; height: 18px;">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td>
+                        <table id="code" border-style="none" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                                <td style="font-size: 0px; width: 12px">&nbsp;</td>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                                <td style="font-size: 0px; width: 12px">&nbsp;</td>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                                <td style="font-size: 0px; width: 12px">&nbsp;</td>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                                <td style="font-size: 0px; width: 12px">&nbsp;</td>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                                <td style="font-size: 0px; width: 12px">&nbsp;</td>
+                                <td width="53px" height="53px"
+                                    style="font-size: 40px; font-weight: bold; text-align: center; border-radius: 10px; background-color: #EEEEEE;">
+                                    %s
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="font-size: 0px; height: 454px">&nbsp;</td>
+                </tr>
+                <tr>
+                    <td style="font-size: 0px; height: 56px; border-top: 1px solid #c7c7cc;">&nbsp;</td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
close #10 

관련 api 목록
- 메일 중복체크 api
- 인증 메일 전송(회원가입용, 정보 수정용) api
- 메일 인증 api
- 회원가입 api에서 이메일 인증여부 확인로직 추가

인증 메일 전송로직 구현
+ JavaMailSender에서 템플릿에 따라 이메일 전송하는 로직(jmsUtil, AuthCodeFacade) 작성함
지정된 html template에 6자리 랜덤 숫자 넣어서 메일 전송할 수 있도록 함

전송한 6자리 랜덤 숫자는 AuthCode 레포지토리에 이메일과 함께 저장되고,
이메일 인증api에서 입력받은 인증코드가 저장된 정보와 일치하면 인증되었음을 표시해둠

그리고 이메일 인증이 필요한 api에 요청이 들어오면(ex 회원가입) 인증된 이메일인지 조회하여 체크 후 로직실행함

내가 파일마다 하나하나 커밋을 해서 커밋양이 많긴 한데...
커밋을 어떻게 나눠서 해야할지에 대해선 우리가 한번 얘기를 해봐야할듯.
코드 한번 검토해주고 혹시 궁굼한거 있으면 암거나 물어봐 
